### PR TITLE
MOD: specify html.parser

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,13 +12,13 @@ def getXunLeiAccount():
     url = "http://521xunlei.com/portal.php"
     res = urllib2.urlopen(url)
     html = unicode(res.read(), 'GBK').encode('UTF-8')
-    soup = BeautifulSoup(html)
+    soup = BeautifulSoup(html, 'html.parser')
     tag_a = soup.find(id="portal_block_62_content").find_all('a')
     for link in tag_a:
         if (checkLink(link.get("title")) >= 0):
             pageURL = "http://521xunlei.com/" + link.get('href')
             html = urllib2.urlopen(pageURL).read()
-            soup = BeautifulSoup(html)
+            soup = BeautifulSoup(html, 'html.parser')
             content = soup.find_all("td", class_="t_f")[0]
             flag = "迅雷"
             for text in content.get_text().split("\r\n"):

--- a/app2.py
+++ b/app2.py
@@ -11,10 +11,10 @@ from bs4 import BeautifulSoup
 def getXunLeiAccount():
     url = "http://xlfans.com"
     html = getPage(url)
-    soup = BeautifulSoup(html)
+    soup = BeautifulSoup(html, 'html.parser')
     tag_a = soup.find_all("article", class_="excerpt")[0]
     html = getPage(tag_a.find_all("a")[0].get('href'))
-    soup = BeautifulSoup(html)
+    soup = BeautifulSoup(html, 'html.parser')
     tag_p =soup.find_all("p")
     for line in tag_p:
         text=line.get_text().encode('utf-8')


### PR DESCRIPTION
fix warrnning as follows:

/Library/Python/2.7/site-packages/bs4/**init**.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")

  markup_type=markup_type))
